### PR TITLE
fix: Corporate Actions DataSource additional improvements

### DIFF
--- a/tests/fixtures/mock_responses.py
+++ b/tests/fixtures/mock_responses.py
@@ -97,30 +97,36 @@ MOCK_MALFORMED_BAR = {
     "next_page_token": None,
 }
 
-# Single page of corporate actions data
+# Single page of corporate actions data (matches actual API format)
 MOCK_CORPORATE_ACTIONS_RESPONSE = {
     "corporate_actions": {
-        "AAPL": [
+        "cash_dividends": [
             {
-                "ex_date": "2021-02-05T00:00:00Z",
-                "record_date": "2021-02-08T00:00:00Z",
-                "payable_date": "2021-02-11T00:00:00Z",
-                "type": "dividend",
-                "amount": 0.205,
-                "ratio": 1.0,
-                "new_symbol": "",
-                "old_symbol": "AAPL",
-            },
+                "cusip": "037833100",
+                "ex_date": "2021-02-05",
+                "record_date": "2021-02-08",
+                "payable_date": "2021-02-11",
+                "rate": 0.205,
+                "foreign": False,
+                "special": False,
+                "symbol": "AAPL",
+                "id": "dividend-1",
+                "process_date": "2021-02-11"
+            }
+        ],
+        "forward_splits": [
             {
-                "ex_date": "2021-08-30T00:00:00Z",
-                "record_date": "2021-08-30T00:00:00Z",
-                "payable_date": "2021-08-30T00:00:00Z",
-                "type": "split",
-                "amount": 0.0,
-                "ratio": 4.0,
-                "new_symbol": "AAPL",
-                "old_symbol": "AAPL",
-            },
+                "cusip": "037833100",
+                "ex_date": "2021-08-30",
+                "record_date": "2021-08-30",
+                "payable_date": "2021-08-30",
+                "due_bill_redemption_date": "2021-09-01",
+                "new_rate": 4,
+                "old_rate": 1,
+                "symbol": "AAPL",
+                "id": "split-1",
+                "process_date": "2021-08-30"
+            }
         ]
     },
     "next_page_token": None,


### PR DESCRIPTION
Fixes additional Corporate Actions DataSource issues identified in #32:

- Add support for `cuspis` and `ids` parameters to API
- Override `_endpoint_config()` method to use v1 endpoint properly
- Fix path_elements to use correct endpoint path: corporate-actions
- Fix data parsing to handle nested API response structure (action_type -> records)
- Update tests and mock data to match actual API format (YYYY-MM-DD dates)
- Remove date_type parameter support (doesn't exist in actual API)

The DataSource now correctly handles the nested API response structure and supports all parameters mentioned in the API documentation.

Generated with [Claude Code](https://claude.ai/code)